### PR TITLE
Add OSM Changeset Viewer on a GL Map

### DIFF
--- a/addon/_locales/en/messages.json
+++ b/addon/_locales/en/messages.json
@@ -181,6 +181,9 @@
     "site_umap": {
         "message": "uMap"
     },
+    "site_osmchangesetmap": {
+        "message": "OSM Changeset Viewer on a GL Map",
+    },
     "site_osmdeephistory": {
         "message": "OSM Deep History"
     },

--- a/src/sites-configuration.ts
+++ b/src/sites-configuration.ts
@@ -159,6 +159,13 @@ export const Sites: Record<string, DefaultSiteConfiguration> = {
     ]
   },
 
+  osmchangesetmap: {
+    link: 'osmlab.github.io/changeset-map',
+    paramOpts: [
+      { ordered: '/#{changesetId}' },
+    ],
+  },
+
   osmdeephistory: {
     link: "osmlab.github.io/osm-deep-history",
     paramOpts: [


### PR DESCRIPTION
See <https://github.com/osmlab/changeset-map>. This is the changeset
viewer module for OSMCha, but this instance does not require
authorization.