### PR TITLE
Add *waymarkedtrails.org

### DIFF
--- a/src/sites-configuration.ts
+++ b/src/sites-configuration.ts
@@ -513,6 +513,48 @@ export const Sites: Record<string, DefaultSiteConfiguration> = {
     httpOnly: true, // mini-map won't load in HTTPS
     disabledByDefault: true, // doesn't work for most relations
   },
+
+  waymarkedtrailsHiking: {
+    link: "hiking.waymarkedtrails.org",
+    paramOpts: [
+      { ordered: "/#?map={zoom}/{lat}/{lon}" },
+    ],
+  },
+
+  waymarkedtrailsCycling: {
+    link: "cycling.waymarkedtrails.org",
+    paramOpts: [
+      { ordered: "/#?map={zoom}/{lat}/{lon}" },
+    ],
+  },
+
+  waymarkedtrailsMtb: {
+    link: "mtb.waymarkedtrails.org",
+    paramOpts: [
+      { ordered: "/#?map={zoom}/{lat}/{lon}" },
+    ],
+  },
+
+  waymarkedtrailsSkating: {
+    link: "skating.waymarkedtrails.org",
+    paramOpts: [
+      { ordered: "/#?map={zoom}/{lat}/{lon}" },
+    ],
+  },
+
+  waymarkedtrailsRiding: {
+    link: "riding.waymarkedtrails.org",
+    paramOpts: [
+      { ordered: "/#?map={zoom}/{lat}/{lon}" },
+    ],
+  },
+
+  waymarkedtrailsSlopes: {
+    link: "slopes.waymarkedtrails.org",
+    paramOpts: [
+      { ordered: "/#?map={zoom}/{lat}/{lon}" },
+    ],
+  },
 };
 
 function getPermalinkBySelector(selector: string) {


### PR DESCRIPTION
This adds patterns for `https://hiking.waymarkedtrails.org/#?map=17.0/51.0542/12.783` and the other subdomains.

Ideally, there where an option to specify `link: "*.waymarkedtrails.org"` or `link: "waymarkedtrails.org"` as a catch all since the configuration is the same for all subdomains.

---

Closes https://github.com/jgpacker/osm-smart-menu/issues/192