### PR TITLE
Add Rapid Editor

### DIFF
--- a/addon/_locales/en/messages.json
+++ b/addon/_locales/en/messages.json
@@ -175,6 +175,9 @@
     "site_level0": {
         "message": "Level0 Editor"
     },
+    "site_rapideditor": {
+        "message": "Rapid Editor"
+    },
     "site_ideditor": {
         "message": "iD Editor"
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test": "jest",
     "tscompile": "svelte-check && webpack --mode=production",
     "watch": "npm run tscompile -- --watch",
-    "build": "npm run tscompile && web-ext build --source-dir addon"
+    "build": "npm run tscompile && web-ext build --overwrite-dest --source-dir addon"
   },
   "repository": {
     "type": "git",

--- a/src/sites-configuration.ts
+++ b/src/sites-configuration.ts
@@ -64,6 +64,20 @@ export const Sites: Record<string, DefaultSiteConfiguration> = {
     }
   },
 
+  rapideditor: {
+    link: "rapideditor.org",
+    paramOpts: [
+      { ordered: "/edit#map={zoom}/{lat}/{lon}" },   // set params
+      { ordered: "/edit#id=n{nodeId}" },             // set params
+      { ordered: "/edit#id=w{wayId}" },              // set params
+      { ordered: "/edit#id=r{relationId}" },         // set params
+      { ordered: "map={zoom}/{lat}/{lon}" },         // gather params
+      { ordered: "id=n{nodeId}" },                   // gather params
+      { ordered: "id=w{wayId}" },                    // gather params
+      { ordered: "id=r{relationId}" }                // gather params
+    ],
+  },
+
   ideditor: {
     link: "www.openstreetmap.org/edit",
     paramOpts: [


### PR DESCRIPTION
Hey @jgpacker thanks for developing the osm-smart-menu extension!

This PR simply adds support for the Rapid Editor.  
I tested it locally and was able to use the menu to navigate between rapideditor.org and other sites like openstreetmap.org  👍 

This new site is the home for the Rapid Editor:  https://rapideditor.org/  
(We are deprecating the older https://mapwith.ai site)

More info about Rapid here: 
https://wiki.openstreetmap.org/wiki/Rapid

closes #38 
